### PR TITLE
Fix getting client_id and auth_url for login endpoint

### DIFF
--- a/amodeus/upstream/credentials.py
+++ b/amodeus/upstream/credentials.py
@@ -106,9 +106,8 @@ class ModeusCredentials:
         session = AsyncClient(http2=True, base_url="https://utmn.modeus.org/", timeout=15)
         # Getting app config
         r = await session.get("/schedule-calendar/assets/app.config.json")
-        data = r.json()["legacy"]["appConfig"]["httpAuth"]
-        auth_url = data["authUrl"]
-        client_id = data["clientId"]
+        client_id = r.json()["wso"]["clientId"]
+        auth_url = r.json()["wso"]["loginUrl"]
         # Getting auth URL
         auth_data = dict(
             client_id=client_id,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   api:
-    image: ghcr.io/amodeus-app/amodeus-api
+    # image: ghcr.io/amodeus-app/amodeus-api
+    build:
+      context: .
     restart: unless-stopped
     cap_drop:
       - ALL


### PR DESCRIPTION
1. JSON schema of login endpoint was changed. Now it does not have "legacy" key. Use "wso" instead.
2. Temporarily changed docker build settings in docker-compose.yaml for debugging application. 